### PR TITLE
CI-215 Improve error handling on API actions

### DIFF
--- a/cirro_api_client/v1/api/audit/get_event.py
+++ b/cirro_api_client/v1/api/audit/get_event.py
@@ -25,10 +25,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Aud
         response_200 = AuditEvent.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[AuditEvent]:
@@ -94,10 +92,13 @@ def sync(
         AuditEvent
     """
 
-    return sync_detailed(
-        audit_event_id=audit_event_id,
-        client=client,
-    ).parsed
+    try:
+        return sync_detailed(
+            audit_event_id=audit_event_id,
+            client=client,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -151,9 +152,12 @@ async def asyncio(
         AuditEvent
     """
 
-    return (
-        await asyncio_detailed(
-            audit_event_id=audit_event_id,
-            client=client,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                audit_event_id=audit_event_id,
+                client=client,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/audit/list_events.py
+++ b/cirro_api_client/v1/api/audit/list_events.py
@@ -38,10 +38,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Lis
             response_200.append(response_200_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[List["AuditEvent"]]:
@@ -107,10 +105,13 @@ def sync(
         List['AuditEvent']
     """
 
-    return sync_detailed(
-        client=client,
-        username=username,
-    ).parsed
+    try:
+        return sync_detailed(
+            client=client,
+            username=username,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -164,9 +165,12 @@ async def asyncio(
         List['AuditEvent']
     """
 
-    return (
-        await asyncio_detailed(
-            client=client,
-            username=username,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                client=client,
+                username=username,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/billing/create_billing_account.py
+++ b/cirro_api_client/v1/api/billing/create_billing_account.py
@@ -35,10 +35,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Cre
         response_201 = CreateResponse.from_dict(response.json())
 
         return response_201
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[CreateResponse]:
@@ -104,10 +102,13 @@ def sync(
         CreateResponse
     """
 
-    return sync_detailed(
-        client=client,
-        body=body,
-    ).parsed
+    try:
+        return sync_detailed(
+            client=client,
+            body=body,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -161,9 +162,12 @@ async def asyncio(
         CreateResponse
     """
 
-    return (
-        await asyncio_detailed(
-            client=client,
-            body=body,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                client=client,
+                body=body,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/billing/delete_billing_account.py
+++ b/cirro_api_client/v1/api/billing/delete_billing_account.py
@@ -22,10 +22,8 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:

--- a/cirro_api_client/v1/api/billing/generate_billing_report.py
+++ b/cirro_api_client/v1/api/billing/generate_billing_report.py
@@ -18,10 +18,7 @@ def _get_kwargs() -> Dict[str, Any]:
 
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:

--- a/cirro_api_client/v1/api/billing/get_billing_accounts.py
+++ b/cirro_api_client/v1/api/billing/get_billing_accounts.py
@@ -38,10 +38,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Lis
             response_200.append(response_200_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[List["BillingAccount"]]:
@@ -107,10 +105,13 @@ def sync(
         List['BillingAccount']
     """
 
-    return sync_detailed(
-        client=client,
-        include_archived=include_archived,
-    ).parsed
+    try:
+        return sync_detailed(
+            client=client,
+            include_archived=include_archived,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -164,9 +165,12 @@ async def asyncio(
         List['BillingAccount']
     """
 
-    return (
-        await asyncio_detailed(
-            client=client,
-            include_archived=include_archived,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                client=client,
+                include_archived=include_archived,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/billing/update_billing_account.py
+++ b/cirro_api_client/v1/api/billing/update_billing_account.py
@@ -33,10 +33,8 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:

--- a/cirro_api_client/v1/api/dashboards/delete_dashboard.py
+++ b/cirro_api_client/v1/api/dashboards/delete_dashboard.py
@@ -26,10 +26,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Das
         response_204 = Dashboard.from_dict(response.json())
 
         return response_204
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Dashboard]:
@@ -100,11 +98,14 @@ def sync(
         Dashboard
     """
 
-    return sync_detailed(
-        project_id=project_id,
-        dashboard_id=dashboard_id,
-        client=client,
-    ).parsed
+    try:
+        return sync_detailed(
+            project_id=project_id,
+            dashboard_id=dashboard_id,
+            client=client,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -163,10 +164,13 @@ async def asyncio(
         Dashboard
     """
 
-    return (
-        await asyncio_detailed(
-            project_id=project_id,
-            dashboard_id=dashboard_id,
-            client=client,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                project_id=project_id,
+                dashboard_id=dashboard_id,
+                client=client,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/dashboards/get_dashboard.py
+++ b/cirro_api_client/v1/api/dashboards/get_dashboard.py
@@ -26,10 +26,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Das
         response_200 = Dashboard.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Dashboard]:
@@ -100,11 +98,14 @@ def sync(
         Dashboard
     """
 
-    return sync_detailed(
-        project_id=project_id,
-        dashboard_id=dashboard_id,
-        client=client,
-    ).parsed
+    try:
+        return sync_detailed(
+            project_id=project_id,
+            dashboard_id=dashboard_id,
+            client=client,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -163,10 +164,13 @@ async def asyncio(
         Dashboard
     """
 
-    return (
-        await asyncio_detailed(
-            project_id=project_id,
-            dashboard_id=dashboard_id,
-            client=client,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                project_id=project_id,
+                dashboard_id=dashboard_id,
+                client=client,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/dashboards/get_dashboards.py
+++ b/cirro_api_client/v1/api/dashboards/get_dashboards.py
@@ -30,10 +30,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Lis
             response_200.append(response_200_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[List["Dashboard"]]:
@@ -99,10 +97,13 @@ def sync(
         List['Dashboard']
     """
 
-    return sync_detailed(
-        project_id=project_id,
-        client=client,
-    ).parsed
+    try:
+        return sync_detailed(
+            project_id=project_id,
+            client=client,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -156,9 +157,12 @@ async def asyncio(
         List['Dashboard']
     """
 
-    return (
-        await asyncio_detailed(
-            project_id=project_id,
-            client=client,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                project_id=project_id,
+                client=client,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/dashboards/update_dashboard.py
+++ b/cirro_api_client/v1/api/dashboards/update_dashboard.py
@@ -37,10 +37,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Das
         response_200 = Dashboard.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Dashboard]:
@@ -116,12 +114,15 @@ def sync(
         Dashboard
     """
 
-    return sync_detailed(
-        project_id=project_id,
-        dashboard_id=dashboard_id,
-        client=client,
-        body=body,
-    ).parsed
+    try:
+        return sync_detailed(
+            project_id=project_id,
+            dashboard_id=dashboard_id,
+            client=client,
+            body=body,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -185,11 +186,14 @@ async def asyncio(
         Dashboard
     """
 
-    return (
-        await asyncio_detailed(
-            project_id=project_id,
-            dashboard_id=dashboard_id,
-            client=client,
-            body=body,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                project_id=project_id,
+                dashboard_id=dashboard_id,
+                client=client,
+                body=body,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/datasets/delete_dataset.py
+++ b/cirro_api_client/v1/api/datasets/delete_dataset.py
@@ -23,10 +23,8 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.ACCEPTED:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:

--- a/cirro_api_client/v1/api/datasets/get_dataset_manifest.py
+++ b/cirro_api_client/v1/api/datasets/get_dataset_manifest.py
@@ -38,10 +38,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Dat
         response_200 = DatasetAssetsManifest.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[DatasetAssetsManifest]:
@@ -122,13 +120,16 @@ def sync(
         DatasetAssetsManifest
     """
 
-    return sync_detailed(
-        project_id=project_id,
-        dataset_id=dataset_id,
-        client=client,
-        file_offset=file_offset,
-        file_limit=file_limit,
-    ).parsed
+    try:
+        return sync_detailed(
+            project_id=project_id,
+            dataset_id=dataset_id,
+            client=client,
+            file_offset=file_offset,
+            file_limit=file_limit,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -197,12 +198,15 @@ async def asyncio(
         DatasetAssetsManifest
     """
 
-    return (
-        await asyncio_detailed(
-            project_id=project_id,
-            dataset_id=dataset_id,
-            client=client,
-            file_offset=file_offset,
-            file_limit=file_limit,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                project_id=project_id,
+                dataset_id=dataset_id,
+                client=client,
+                file_offset=file_offset,
+                file_limit=file_limit,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/datasets/ingest_samples.py
+++ b/cirro_api_client/v1/api/datasets/ingest_samples.py
@@ -23,10 +23,8 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.ACCEPTED:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:

--- a/cirro_api_client/v1/api/datasets/regenerate_manifest.py
+++ b/cirro_api_client/v1/api/datasets/regenerate_manifest.py
@@ -23,10 +23,8 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.ACCEPTED:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:

--- a/cirro_api_client/v1/api/datasets/rerun_transform.py
+++ b/cirro_api_client/v1/api/datasets/rerun_transform.py
@@ -23,10 +23,8 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.ACCEPTED:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:

--- a/cirro_api_client/v1/api/datasets/upload_dataset.py
+++ b/cirro_api_client/v1/api/datasets/upload_dataset.py
@@ -36,10 +36,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Upl
         response_201 = UploadDatasetCreateResponse.from_dict(response.json())
 
         return response_201
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[UploadDatasetCreateResponse]:
@@ -110,11 +108,14 @@ def sync(
         UploadDatasetCreateResponse
     """
 
-    return sync_detailed(
-        project_id=project_id,
-        client=client,
-        body=body,
-    ).parsed
+    try:
+        return sync_detailed(
+            project_id=project_id,
+            client=client,
+            body=body,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -173,10 +174,13 @@ async def asyncio(
         UploadDatasetCreateResponse
     """
 
-    return (
-        await asyncio_detailed(
-            project_id=project_id,
-            client=client,
-            body=body,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                project_id=project_id,
+                client=client,
+                body=body,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/execution/get_execution_logs.py
+++ b/cirro_api_client/v1/api/execution/get_execution_logs.py
@@ -35,10 +35,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Get
         response_200 = GetExecutionLogsResponse.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[GetExecutionLogsResponse]:
@@ -114,12 +112,15 @@ def sync(
         GetExecutionLogsResponse
     """
 
-    return sync_detailed(
-        project_id=project_id,
-        dataset_id=dataset_id,
-        client=client,
-        force_live=force_live,
-    ).parsed
+    try:
+        return sync_detailed(
+            project_id=project_id,
+            dataset_id=dataset_id,
+            client=client,
+            force_live=force_live,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -183,11 +184,14 @@ async def asyncio(
         GetExecutionLogsResponse
     """
 
-    return (
-        await asyncio_detailed(
-            project_id=project_id,
-            dataset_id=dataset_id,
-            client=client,
-            force_live=force_live,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                project_id=project_id,
+                dataset_id=dataset_id,
+                client=client,
+                force_live=force_live,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/execution/get_project_summary.py
+++ b/cirro_api_client/v1/api/execution/get_project_summary.py
@@ -34,10 +34,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Get
         response_200 = GetProjectSummaryResponse200.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[GetProjectSummaryResponse200]:
@@ -108,11 +106,14 @@ def sync(
         GetProjectSummaryResponse200
     """
 
-    return sync_detailed(
-        project_id=project_id,
-        client=client,
-        number_of_days=number_of_days,
-    ).parsed
+    try:
+        return sync_detailed(
+            project_id=project_id,
+            client=client,
+            number_of_days=number_of_days,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -171,10 +172,13 @@ async def asyncio(
         GetProjectSummaryResponse200
     """
 
-    return (
-        await asyncio_detailed(
-            project_id=project_id,
-            client=client,
-            number_of_days=number_of_days,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                project_id=project_id,
+                client=client,
+                number_of_days=number_of_days,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/execution/get_task_logs.py
+++ b/cirro_api_client/v1/api/execution/get_task_logs.py
@@ -36,10 +36,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Get
         response_200 = GetExecutionLogsResponse.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[GetExecutionLogsResponse]:
@@ -120,13 +118,16 @@ def sync(
         GetExecutionLogsResponse
     """
 
-    return sync_detailed(
-        project_id=project_id,
-        dataset_id=dataset_id,
-        task_id=task_id,
-        client=client,
-        force_live=force_live,
-    ).parsed
+    try:
+        return sync_detailed(
+            project_id=project_id,
+            dataset_id=dataset_id,
+            task_id=task_id,
+            client=client,
+            force_live=force_live,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -195,12 +196,15 @@ async def asyncio(
         GetExecutionLogsResponse
     """
 
-    return (
-        await asyncio_detailed(
-            project_id=project_id,
-            dataset_id=dataset_id,
-            task_id=task_id,
-            client=client,
-            force_live=force_live,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                project_id=project_id,
+                dataset_id=dataset_id,
+                task_id=task_id,
+                client=client,
+                force_live=force_live,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/execution/run_analysis.py
+++ b/cirro_api_client/v1/api/execution/run_analysis.py
@@ -36,10 +36,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Cre
         response_200 = CreateResponse.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[CreateResponse]:
@@ -110,11 +108,14 @@ def sync(
         CreateResponse
     """
 
-    return sync_detailed(
-        project_id=project_id,
-        client=client,
-        body=body,
-    ).parsed
+    try:
+        return sync_detailed(
+            project_id=project_id,
+            client=client,
+            body=body,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -173,10 +174,13 @@ async def asyncio(
         CreateResponse
     """
 
-    return (
-        await asyncio_detailed(
-            project_id=project_id,
-            client=client,
-            body=body,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                project_id=project_id,
+                client=client,
+                body=body,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/execution/stop_analysis.py
+++ b/cirro_api_client/v1/api/execution/stop_analysis.py
@@ -26,10 +26,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Sto
         response_200 = StopExecutionResponse.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[StopExecutionResponse]:
@@ -100,11 +98,14 @@ def sync(
         StopExecutionResponse
     """
 
-    return sync_detailed(
-        project_id=project_id,
-        dataset_id=dataset_id,
-        client=client,
-    ).parsed
+    try:
+        return sync_detailed(
+            project_id=project_id,
+            dataset_id=dataset_id,
+            client=client,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -163,10 +164,13 @@ async def asyncio(
         StopExecutionResponse
     """
 
-    return (
-        await asyncio_detailed(
-            project_id=project_id,
-            dataset_id=dataset_id,
-            client=client,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                project_id=project_id,
+                dataset_id=dataset_id,
+                client=client,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/file/generate_project_file_access_token.py
+++ b/cirro_api_client/v1/api/file/generate_project_file_access_token.py
@@ -36,10 +36,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[AWS
         response_200 = AWSCredentials.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[AWSCredentials]:
@@ -110,11 +108,14 @@ def sync(
         AWSCredentials
     """
 
-    return sync_detailed(
-        project_id=project_id,
-        client=client,
-        body=body,
-    ).parsed
+    try:
+        return sync_detailed(
+            project_id=project_id,
+            client=client,
+            body=body,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -173,10 +174,13 @@ async def asyncio(
         AWSCredentials
     """
 
-    return (
-        await asyncio_detailed(
-            project_id=project_id,
-            client=client,
-            body=body,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                project_id=project_id,
+                client=client,
+                body=body,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/file/generate_project_sftp_token.py
+++ b/cirro_api_client/v1/api/file/generate_project_sftp_token.py
@@ -36,10 +36,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Sft
         response_200 = SftpCredentials.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[SftpCredentials]:
@@ -110,11 +108,14 @@ def sync(
         SftpCredentials
     """
 
-    return sync_detailed(
-        project_id=project_id,
-        client=client,
-        body=body,
-    ).parsed
+    try:
+        return sync_detailed(
+            project_id=project_id,
+            client=client,
+            body=body,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -173,10 +174,13 @@ async def asyncio(
         SftpCredentials
     """
 
-    return (
-        await asyncio_detailed(
-            project_id=project_id,
-            client=client,
-            body=body,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                project_id=project_id,
+                client=client,
+                body=body,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/metadata/get_project_samples.py
+++ b/cirro_api_client/v1/api/metadata/get_project_samples.py
@@ -37,10 +37,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Pag
         response_200 = PaginatedResponseSampleDto.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[PaginatedResponseSampleDto]:
@@ -116,12 +114,15 @@ def sync(
         PaginatedResponseSampleDto
     """
 
-    return sync_detailed(
-        project_id=project_id,
-        client=client,
-        limit=limit,
-        next_token=next_token,
-    ).parsed
+    try:
+        return sync_detailed(
+            project_id=project_id,
+            client=client,
+            limit=limit,
+            next_token=next_token,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -185,11 +186,14 @@ async def asyncio(
         PaginatedResponseSampleDto
     """
 
-    return (
-        await asyncio_detailed(
-            project_id=project_id,
-            client=client,
-            limit=limit,
-            next_token=next_token,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                project_id=project_id,
+                client=client,
+                limit=limit,
+                next_token=next_token,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/metadata/update_project_schema.py
+++ b/cirro_api_client/v1/api/metadata/update_project_schema.py
@@ -33,10 +33,8 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:

--- a/cirro_api_client/v1/api/metrics/get_all_metrics.py
+++ b/cirro_api_client/v1/api/metrics/get_all_metrics.py
@@ -28,10 +28,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Lis
             response_200.append(response_200_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[List["ProjectMetrics"]]:
@@ -85,9 +83,12 @@ def sync(
         List['ProjectMetrics']
     """
 
-    return sync_detailed(
-        client=client,
-    ).parsed
+    try:
+        return sync_detailed(
+            client=client,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -129,8 +130,11 @@ async def asyncio(
         List['ProjectMetrics']
     """
 
-    return (
-        await asyncio_detailed(
-            client=client,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                client=client,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/metrics/get_project_metrics.py
+++ b/cirro_api_client/v1/api/metrics/get_project_metrics.py
@@ -25,10 +25,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Pro
         response_200 = ProjectMetrics.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[ProjectMetrics]:
@@ -94,10 +92,13 @@ def sync(
         ProjectMetrics
     """
 
-    return sync_detailed(
-        project_id=project_id,
-        client=client,
-    ).parsed
+    try:
+        return sync_detailed(
+            project_id=project_id,
+            client=client,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -151,9 +152,12 @@ async def asyncio(
         ProjectMetrics
     """
 
-    return (
-        await asyncio_detailed(
-            project_id=project_id,
-            client=client,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                project_id=project_id,
+                client=client,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/notebooks/delete_notebook_instance.py
+++ b/cirro_api_client/v1/api/notebooks/delete_notebook_instance.py
@@ -23,10 +23,8 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.ACCEPTED:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:

--- a/cirro_api_client/v1/api/notebooks/generate_notebook_instance_url.py
+++ b/cirro_api_client/v1/api/notebooks/generate_notebook_instance_url.py
@@ -26,10 +26,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Ope
         response_200 = OpenNotebookInstanceResponse.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[OpenNotebookInstanceResponse]:
@@ -100,11 +98,14 @@ def sync(
         OpenNotebookInstanceResponse
     """
 
-    return sync_detailed(
-        project_id=project_id,
-        notebook_instance_id=notebook_instance_id,
-        client=client,
-    ).parsed
+    try:
+        return sync_detailed(
+            project_id=project_id,
+            notebook_instance_id=notebook_instance_id,
+            client=client,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -163,10 +164,13 @@ async def asyncio(
         OpenNotebookInstanceResponse
     """
 
-    return (
-        await asyncio_detailed(
-            project_id=project_id,
-            notebook_instance_id=notebook_instance_id,
-            client=client,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                project_id=project_id,
+                notebook_instance_id=notebook_instance_id,
+                client=client,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/notebooks/get_notebook_instance_status.py
+++ b/cirro_api_client/v1/api/notebooks/get_notebook_instance_status.py
@@ -26,10 +26,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Not
         response_200 = NotebookInstanceStatusResponse.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[NotebookInstanceStatusResponse]:
@@ -100,11 +98,14 @@ def sync(
         NotebookInstanceStatusResponse
     """
 
-    return sync_detailed(
-        project_id=project_id,
-        notebook_instance_id=notebook_instance_id,
-        client=client,
-    ).parsed
+    try:
+        return sync_detailed(
+            project_id=project_id,
+            notebook_instance_id=notebook_instance_id,
+            client=client,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -163,10 +164,13 @@ async def asyncio(
         NotebookInstanceStatusResponse
     """
 
-    return (
-        await asyncio_detailed(
-            project_id=project_id,
-            notebook_instance_id=notebook_instance_id,
-            client=client,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                project_id=project_id,
+                notebook_instance_id=notebook_instance_id,
+                client=client,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/notebooks/get_notebook_instances.py
+++ b/cirro_api_client/v1/api/notebooks/get_notebook_instances.py
@@ -30,10 +30,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Lis
             response_200.append(response_200_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[List["NotebookInstance"]]:
@@ -99,10 +97,13 @@ def sync(
         List['NotebookInstance']
     """
 
-    return sync_detailed(
-        project_id=project_id,
-        client=client,
-    ).parsed
+    try:
+        return sync_detailed(
+            project_id=project_id,
+            client=client,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -156,9 +157,12 @@ async def asyncio(
         List['NotebookInstance']
     """
 
-    return (
-        await asyncio_detailed(
-            project_id=project_id,
-            client=client,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                project_id=project_id,
+                client=client,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/notebooks/stop_notebook_instance.py
+++ b/cirro_api_client/v1/api/notebooks/stop_notebook_instance.py
@@ -23,10 +23,8 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.ACCEPTED:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:

--- a/cirro_api_client/v1/api/processes/archive_custom_process.py
+++ b/cirro_api_client/v1/api/processes/archive_custom_process.py
@@ -22,10 +22,8 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:

--- a/cirro_api_client/v1/api/processes/create_custom_process.py
+++ b/cirro_api_client/v1/api/processes/create_custom_process.py
@@ -47,10 +47,8 @@ def _parse_response(
         response_201 = CreateResponse.from_dict(response.json())
 
         return response_201
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(
@@ -118,10 +116,13 @@ def sync(
         Union[CreateResponse, ErrorMessage, PortalErrorResponse]
     """
 
-    return sync_detailed(
-        client=client,
-        body=body,
-    ).parsed
+    try:
+        return sync_detailed(
+            client=client,
+            body=body,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -175,9 +176,12 @@ async def asyncio(
         Union[CreateResponse, ErrorMessage, PortalErrorResponse]
     """
 
-    return (
-        await asyncio_detailed(
-            client=client,
-            body=body,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                client=client,
+                body=body,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/processes/get_process.py
+++ b/cirro_api_client/v1/api/processes/get_process.py
@@ -25,10 +25,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Pro
         response_200 = ProcessDetail.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[ProcessDetail]:
@@ -94,10 +92,13 @@ def sync(
         ProcessDetail
     """
 
-    return sync_detailed(
-        process_id=process_id,
-        client=client,
-    ).parsed
+    try:
+        return sync_detailed(
+            process_id=process_id,
+            client=client,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -151,9 +152,12 @@ async def asyncio(
         ProcessDetail
     """
 
-    return (
-        await asyncio_detailed(
-            process_id=process_id,
-            client=client,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                process_id=process_id,
+                client=client,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/processes/get_process_parameters.py
+++ b/cirro_api_client/v1/api/processes/get_process_parameters.py
@@ -25,10 +25,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[For
         response_200 = FormSchema.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[FormSchema]:
@@ -94,10 +92,13 @@ def sync(
         FormSchema
     """
 
-    return sync_detailed(
-        process_id=process_id,
-        client=client,
-    ).parsed
+    try:
+        return sync_detailed(
+            process_id=process_id,
+            client=client,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -151,9 +152,12 @@ async def asyncio(
         FormSchema
     """
 
-    return (
-        await asyncio_detailed(
-            process_id=process_id,
-            client=client,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                process_id=process_id,
+                client=client,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/processes/update_custom_process.py
+++ b/cirro_api_client/v1/api/processes/update_custom_process.py
@@ -33,10 +33,8 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:

--- a/cirro_api_client/v1/api/processes/validate_file_requirements.py
+++ b/cirro_api_client/v1/api/processes/validate_file_requirements.py
@@ -36,10 +36,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Fil
         response_200 = FileRequirements.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[FileRequirements]:
@@ -110,11 +108,14 @@ def sync(
         FileRequirements
     """
 
-    return sync_detailed(
-        process_id=process_id,
-        client=client,
-        body=body,
-    ).parsed
+    try:
+        return sync_detailed(
+            process_id=process_id,
+            client=client,
+            body=body,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -173,10 +174,13 @@ async def asyncio(
         FileRequirements
     """
 
-    return (
-        await asyncio_detailed(
-            process_id=process_id,
-            client=client,
-            body=body,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                process_id=process_id,
+                client=client,
+                body=body,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/projects/create_project.py
+++ b/cirro_api_client/v1/api/projects/create_project.py
@@ -35,10 +35,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Cre
         response_201 = CreateResponse.from_dict(response.json())
 
         return response_201
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[CreateResponse]:
@@ -104,10 +102,13 @@ def sync(
         CreateResponse
     """
 
-    return sync_detailed(
-        client=client,
-        body=body,
-    ).parsed
+    try:
+        return sync_detailed(
+            client=client,
+            body=body,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -161,9 +162,12 @@ async def asyncio(
         CreateResponse
     """
 
-    return (
-        await asyncio_detailed(
-            client=client,
-            body=body,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                client=client,
+                body=body,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/projects/get_project.py
+++ b/cirro_api_client/v1/api/projects/get_project.py
@@ -25,10 +25,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Pro
         response_200 = ProjectDetail.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[ProjectDetail]:
@@ -94,10 +92,13 @@ def sync(
         ProjectDetail
     """
 
-    return sync_detailed(
-        project_id=project_id,
-        client=client,
-    ).parsed
+    try:
+        return sync_detailed(
+            project_id=project_id,
+            client=client,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -151,9 +152,12 @@ async def asyncio(
         ProjectDetail
     """
 
-    return (
-        await asyncio_detailed(
-            project_id=project_id,
-            client=client,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                project_id=project_id,
+                client=client,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/projects/get_projects.py
+++ b/cirro_api_client/v1/api/projects/get_projects.py
@@ -28,10 +28,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Lis
             response_200.append(response_200_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[List["Project"]]:
@@ -85,9 +83,12 @@ def sync(
         List['Project']
     """
 
-    return sync_detailed(
-        client=client,
-    ).parsed
+    try:
+        return sync_detailed(
+            client=client,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -129,8 +130,11 @@ async def asyncio(
         List['Project']
     """
 
-    return (
-        await asyncio_detailed(
-            client=client,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                client=client,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/projects/redeploy_project.py
+++ b/cirro_api_client/v1/api/projects/redeploy_project.py
@@ -22,10 +22,8 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.ACCEPTED:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:

--- a/cirro_api_client/v1/api/projects/set_user_project_role.py
+++ b/cirro_api_client/v1/api/projects/set_user_project_role.py
@@ -33,10 +33,8 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:

--- a/cirro_api_client/v1/api/projects/update_project.py
+++ b/cirro_api_client/v1/api/projects/update_project.py
@@ -36,10 +36,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Pro
         response_200 = ProjectDetail.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[ProjectDetail]:
@@ -110,11 +108,14 @@ def sync(
         ProjectDetail
     """
 
-    return sync_detailed(
-        project_id=project_id,
-        client=client,
-        body=body,
-    ).parsed
+    try:
+        return sync_detailed(
+            project_id=project_id,
+            client=client,
+            body=body,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -173,10 +174,13 @@ async def asyncio(
         ProjectDetail
     """
 
-    return (
-        await asyncio_detailed(
-            project_id=project_id,
-            client=client,
-            body=body,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                project_id=project_id,
+                client=client,
+                body=body,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/projects/update_project_tags.py
+++ b/cirro_api_client/v1/api/projects/update_project_tags.py
@@ -36,10 +36,8 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:

--- a/cirro_api_client/v1/api/references/create_project_reference.py
+++ b/cirro_api_client/v1/api/references/create_project_reference.py
@@ -36,10 +36,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Ref
         response_200 = Reference.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Reference]:
@@ -110,11 +108,14 @@ def sync(
         Reference
     """
 
-    return sync_detailed(
-        project_id=project_id,
-        client=client,
-        body=body,
-    ).parsed
+    try:
+        return sync_detailed(
+            project_id=project_id,
+            client=client,
+            body=body,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -173,10 +174,13 @@ async def asyncio(
         Reference
     """
 
-    return (
-        await asyncio_detailed(
-            project_id=project_id,
-            client=client,
-            body=body,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                project_id=project_id,
+                client=client,
+                body=body,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/references/delete_project_reference.py
+++ b/cirro_api_client/v1/api/references/delete_project_reference.py
@@ -22,10 +22,8 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:

--- a/cirro_api_client/v1/api/references/get_reference_types.py
+++ b/cirro_api_client/v1/api/references/get_reference_types.py
@@ -28,10 +28,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Lis
             response_200.append(response_200_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[List["ReferenceType"]]:
@@ -85,9 +83,12 @@ def sync(
         List['ReferenceType']
     """
 
-    return sync_detailed(
-        client=client,
-    ).parsed
+    try:
+        return sync_detailed(
+            client=client,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -129,8 +130,11 @@ async def asyncio(
         List['ReferenceType']
     """
 
-    return (
-        await asyncio_detailed(
-            client=client,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                client=client,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/references/get_references.py
+++ b/cirro_api_client/v1/api/references/get_references.py
@@ -28,10 +28,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Lis
             response_200.append(response_200_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[List["Reference"]]:
@@ -85,9 +83,12 @@ def sync(
         List['Reference']
     """
 
-    return sync_detailed(
-        client=client,
-    ).parsed
+    try:
+        return sync_detailed(
+            client=client,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -129,8 +130,11 @@ async def asyncio(
         List['Reference']
     """
 
-    return (
-        await asyncio_detailed(
-            client=client,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                client=client,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/references/get_references_for_project.py
+++ b/cirro_api_client/v1/api/references/get_references_for_project.py
@@ -30,10 +30,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Lis
             response_200.append(response_200_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[List["Reference"]]:
@@ -99,10 +97,13 @@ def sync(
         List['Reference']
     """
 
-    return sync_detailed(
-        project_id=project_id,
-        client=client,
-    ).parsed
+    try:
+        return sync_detailed(
+            project_id=project_id,
+            client=client,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -156,9 +157,12 @@ async def asyncio(
         List['Reference']
     """
 
-    return (
-        await asyncio_detailed(
-            project_id=project_id,
-            client=client,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                project_id=project_id,
+                client=client,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/references/refresh_project_references.py
+++ b/cirro_api_client/v1/api/references/refresh_project_references.py
@@ -22,10 +22,8 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:

--- a/cirro_api_client/v1/api/system/get_service_connections.py
+++ b/cirro_api_client/v1/api/system/get_service_connections.py
@@ -28,10 +28,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Lis
             response_200.append(response_200_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[List["ServiceConnection"]]:
@@ -85,9 +83,12 @@ def sync(
         List['ServiceConnection']
     """
 
-    return sync_detailed(
-        client=client,
-    ).parsed
+    try:
+        return sync_detailed(
+            client=client,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -129,8 +130,11 @@ async def asyncio(
         List['ServiceConnection']
     """
 
-    return (
-        await asyncio_detailed(
-            client=client,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                client=client,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/system/info.py
+++ b/cirro_api_client/v1/api/system/info.py
@@ -23,10 +23,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Sys
         response_200 = SystemInfoResponse.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[SystemInfoResponse]:
@@ -76,9 +74,12 @@ def sync(
         SystemInfoResponse
     """
 
-    return sync_detailed(
-        client=client,
-    ).parsed
+    try:
+        return sync_detailed(
+            client=client,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -116,8 +117,11 @@ async def asyncio(
         SystemInfoResponse
     """
 
-    return (
-        await asyncio_detailed(
-            client=client,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                client=client,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/users/get_user.py
+++ b/cirro_api_client/v1/api/users/get_user.py
@@ -25,10 +25,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Use
         response_200 = UserDetail.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[UserDetail]:
@@ -94,10 +92,13 @@ def sync(
         UserDetail
     """
 
-    return sync_detailed(
-        username=username,
-        client=client,
-    ).parsed
+    try:
+        return sync_detailed(
+            username=username,
+            client=client,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -151,9 +152,12 @@ async def asyncio(
         UserDetail
     """
 
-    return (
-        await asyncio_detailed(
-            username=username,
-            client=client,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                username=username,
+                client=client,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/users/get_users.py
+++ b/cirro_api_client/v1/api/users/get_users.py
@@ -38,10 +38,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Lis
             response_200.append(response_200_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[List["User"]]:
@@ -107,10 +105,13 @@ def sync(
         List['User']
     """
 
-    return sync_detailed(
-        client=client,
-        username=username,
-    ).parsed
+    try:
+        return sync_detailed(
+            client=client,
+            username=username,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -164,9 +165,12 @@ async def asyncio(
         List['User']
     """
 
-    return (
-        await asyncio_detailed(
-            client=client,
-            username=username,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                client=client,
+                username=username,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/users/invite_user.py
+++ b/cirro_api_client/v1/api/users/invite_user.py
@@ -35,10 +35,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Inv
         response_200 = InviteUserResponse.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[InviteUserResponse]:
@@ -104,10 +102,13 @@ def sync(
         InviteUserResponse
     """
 
-    return sync_detailed(
-        client=client,
-        body=body,
-    ).parsed
+    try:
+        return sync_detailed(
+            client=client,
+            body=body,
+        ).parsed
+    except errors.NotFoundException:
+        return None
 
 
 async def asyncio_detailed(
@@ -161,9 +162,12 @@ async def asyncio(
         InviteUserResponse
     """
 
-    return (
-        await asyncio_detailed(
-            client=client,
-            body=body,
-        )
-    ).parsed
+    try:
+        return (
+            await asyncio_detailed(
+                client=client,
+                body=body,
+            )
+        ).parsed
+    except errors.NotFoundException:
+        return None

--- a/cirro_api_client/v1/api/users/sign_out_user.py
+++ b/cirro_api_client/v1/api/users/sign_out_user.py
@@ -22,10 +22,8 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.ACCEPTED:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:

--- a/cirro_api_client/v1/errors.py
+++ b/cirro_api_client/v1/errors.py
@@ -8,7 +8,7 @@ import httpx
 from cirro_api_client.v1.models import PortalErrorResponse
 
 
-def handle_error_response(response: httpx.Response, raise_on_unexpected_status: bool):
+def handle_error_response(response: httpx.Response, raise_on_unexpected_status: bool) -> None:
     """Parses a response from the server and returns an exception if the response indicates an error"""
     if response.status_code == HTTPStatus.BAD_REQUEST:
         raise BadRequestException(response.json())
@@ -18,9 +18,6 @@ def handle_error_response(response: httpx.Response, raise_on_unexpected_status: 
 
     if response.status_code == HTTPStatus.FORBIDDEN:
         raise ForbiddenException(response.json())
-
-    if response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR:
-        raise InternalServerErrorException(response.json())
 
     if raise_on_unexpected_status:
         raise UnexpectedStatus(response.status_code, response.content)
@@ -57,10 +54,6 @@ class BadRequestException(CirroException):
 
 class ForbiddenException(CirroException):
     """Raised when the user is not authorized to perform the requested action"""
-
-
-class InternalServerErrorException(CirroException):
-    """Raised when the server returns an unexpected error"""
 
 
 __all__ = ["UnexpectedStatus", "NotFoundException", "BadRequestException", "ForbiddenException"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cirro_api_client"
-version = "0.0.11"
+version = "0.1.0"
 description = "A client library for accessing Cirro"
 authors = ["Cirro <support@cirro.bio>"]
 license = "MIT"

--- a/templates/endpoint_module.py.jinja
+++ b/templates/endpoint_module.py.jinja
@@ -84,10 +84,8 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[{{ 
         return None
         {% endif %}
     {% endfor %}
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    errors.handle_error_response(response, client.raise_on_unexpected_status)
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[{{ return_string }}]:
@@ -120,10 +118,12 @@ def sync(
     {{ arguments(endpoint) | indent(4) }}
 ) -> Optional[{{ return_string }}]:
     {{ docstring(endpoint, return_string, is_detailed=false) | indent(4) }}
-
-    return sync_detailed(
-        {{ kwargs(endpoint) }}
-    ).parsed
+    try:
+        return sync_detailed(
+            {{ kwargs(endpoint) }}
+        ).parsed
+    except errors.NotFoundException:
+        return None
 {% endif %}
 
 async def asyncio_detailed(
@@ -148,7 +148,10 @@ async def asyncio(
 ) -> Optional[{{ return_string }}]:
     {{ docstring(endpoint, return_string, is_detailed=false) | indent(4) }}
 
-    return (await asyncio_detailed(
-        {{ kwargs(endpoint) }}
-    )).parsed
+    try:
+        return (await asyncio_detailed(
+            {{ kwargs(endpoint) }}
+        )).parsed
+    except errors.NotFoundException:
+        return None
 {% endif %}

--- a/templates/errors.py.jinja
+++ b/templates/errors.py.jinja
@@ -7,7 +7,7 @@ import httpx
 from cirro_api_client.v1.models import PortalErrorResponse
 
 
-def handle_error_response(response: httpx.Response, raise_on_unexpected_status: bool):
+def handle_error_response(response: httpx.Response, raise_on_unexpected_status: bool) -> None:
     """Parses a response from the server and returns an exception if the response indicates an error"""
     if response.status_code == HTTPStatus.BAD_REQUEST:
         raise BadRequestException(response.json())
@@ -17,9 +17,6 @@ def handle_error_response(response: httpx.Response, raise_on_unexpected_status: 
 
     if response.status_code == HTTPStatus.FORBIDDEN:
         raise ForbiddenException(response.json())
-
-    if response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR:
-        raise InternalServerErrorException(response.json())
 
     if raise_on_unexpected_status:
         raise UnexpectedStatus(response.status_code, response.content)
@@ -49,13 +46,13 @@ class CirroException(Exception):
 class NotFoundException(CirroException):
     """Raised when the item requested is not found"""
 
+
 class BadRequestException(CirroException):
     """Raised when request is invalid"""
+
 
 class ForbiddenException(CirroException):
     """Raised when the user is not authorized to perform the requested action"""
 
-class InternalServerErrorException(CirroException):
-    """Raised when the server returns an unexpected error"""
 
-__all__ = ["UnexpectedStatus", "NotFoundException", "BadRequestException", "ForbiddenException", 'InternalServerErrorException']
+__all__ = ["UnexpectedStatus", "NotFoundException", "BadRequestException", "ForbiddenException"]

--- a/templates/errors.py.jinja
+++ b/templates/errors.py.jinja
@@ -1,5 +1,4 @@
-"""Contains shared errors types that can be raised from API functions"""
-
+""" Contains shared errors types that can be raised from API functions """
 from http import HTTPStatus
 from typing import Dict
 
@@ -50,17 +49,13 @@ class CirroException(Exception):
 class NotFoundException(CirroException):
     """Raised when the item requested is not found"""
 
-
 class BadRequestException(CirroException):
     """Raised when request is invalid"""
-
 
 class ForbiddenException(CirroException):
     """Raised when the user is not authorized to perform the requested action"""
 
-
 class InternalServerErrorException(CirroException):
     """Raised when the server returns an unexpected error"""
 
-
-__all__ = ["UnexpectedStatus", "NotFoundException", "BadRequestException", "ForbiddenException"]
+__all__ = ["UnexpectedStatus", "NotFoundException", "BadRequestException", "ForbiddenException", 'InternalServerErrorException']


### PR DESCRIPTION
CI-215

Add exceptions for various server responses so we can catch properly in the SDK, instead of just using UnexpectedStatus exception.

Regular calls catch the NotFoundException and return None