### PR TITLE
Update PyPI publish action version in workflow - use full hash

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -35,4 +35,4 @@ jobs:
 
       - name: Publish package distributions to PyPI
         if: github.event_name == 'release'
-        uses: pypa/gh-action-pypi-publish@cef2210
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b


### PR DESCRIPTION
Unable to resolve action `pypa/gh-action-pypi-publish@cef2210`, the provided ref `cef2210` is the shortened version of a commit SHA, which is not supported. Please use the full commit SHA `cef221092ed1bacb1cc03d23a2d87d1d172e277b` instead.